### PR TITLE
Update to Portable WebDAV Library v0.6.1.0

### DIFF
--- a/NextcloudApp/project.lock.json
+++ b/NextcloudApp/project.lock.json
@@ -299,7 +299,7 @@
           "lib/portable-net45+wp80+win8+wpa81/Newtonsoft.Json.dll": {}
         }
       },
-      "PortableWebDavLibrary/0.5.1": {
+      "PortableWebDavLibrary/0.6.1": {
         "compile": {
           "lib/portable-Profile32/DecaTec.WebDav.Uwp.dll": {}
         },
@@ -2379,7 +2379,7 @@
           "lib/portable-net45+wp80+win8+wpa81/Newtonsoft.Json.dll": {}
         }
       },
-      "PortableWebDavLibrary/0.5.1": {
+      "PortableWebDavLibrary/0.6.1": {
         "compile": {
           "lib/portable-Profile32/DecaTec.WebDav.Uwp.dll": {}
         },
@@ -4592,7 +4592,7 @@
           "lib/portable-net45+wp80+win8+wpa81/Newtonsoft.Json.dll": {}
         }
       },
-      "PortableWebDavLibrary/0.5.1": {
+      "PortableWebDavLibrary/0.6.1": {
         "compile": {
           "lib/portable-Profile32/DecaTec.WebDav.Uwp.dll": {}
         },
@@ -6846,7 +6846,7 @@
           "lib/portable-net45+wp80+win8+wpa81/Newtonsoft.Json.dll": {}
         }
       },
-      "PortableWebDavLibrary/0.5.1": {
+      "PortableWebDavLibrary/0.6.1": {
         "compile": {
           "lib/portable-Profile32/DecaTec.WebDav.Uwp.dll": {}
         },
@@ -9068,7 +9068,7 @@
           "lib/portable-net45+wp80+win8+wpa81/Newtonsoft.Json.dll": {}
         }
       },
-      "PortableWebDavLibrary/0.5.1": {
+      "PortableWebDavLibrary/0.6.1": {
         "compile": {
           "lib/portable-Profile32/DecaTec.WebDav.Uwp.dll": {}
         },
@@ -11327,7 +11327,7 @@
           "lib/portable-net45+wp80+win8+wpa81/Newtonsoft.Json.dll": {}
         }
       },
-      "PortableWebDavLibrary/0.5.1": {
+      "PortableWebDavLibrary/0.6.1": {
         "compile": {
           "lib/portable-Profile32/DecaTec.WebDav.Uwp.dll": {}
         },
@@ -13549,7 +13549,7 @@
           "lib/portable-net45+wp80+win8+wpa81/Newtonsoft.Json.dll": {}
         }
       },
-      "PortableWebDavLibrary/0.5.1": {
+      "PortableWebDavLibrary/0.6.1": {
         "compile": {
           "lib/portable-Profile32/DecaTec.WebDav.Uwp.dll": {}
         },
@@ -15584,8 +15584,9 @@
       ]
     },
     "Microsoft.CSharp/4.0.1": {
-      "sha512": "17h8b5mXa87XYKrrVqdgZ38JefSUqLChUQpXgSnpzsM0nDOhE40FTeNWOJ/YmySGV6tG6T8+hjz6vxbknHJr6A==",
+      "sha512": "ML+Fsr+5MrFxSGWf5rK2oglQqqGYD768Tmmzlk83Cu6P7hfO5yHlYUqTA98JwNHvMI/0cCShIf4EwW4y8EpM/A==",
       "type": "package",
+      "path": "Microsoft.CSharp/4.0.1",
       "files": [
         "Microsoft.CSharp.4.0.1.nupkg.sha512",
         "Microsoft.CSharp.nuspec",
@@ -15661,8 +15662,9 @@
       ]
     },
     "Microsoft.NETCore.Platforms/1.0.1": {
-      "sha512": "2G6OjjJzwBfNOO8myRV/nFrbTw5iA+DEm0N+qUqhrOmaVtn4pC77h38I1jsXGw5VH55+dPfQsqHD0We9sCl9FQ==",
+      "sha512": "HVRHWcnBoM58npk6VhvooRcJpHb6RkRgbXfxciO2eXqdj1UV49CKDCXkCXNcWBIperK21wr+vTLHGSI33vbZng==",
       "type": "package",
+      "path": "Microsoft.NETCore.Platforms/1.0.1",
       "files": [
         "Microsoft.NETCore.Platforms.1.0.1.nupkg.sha512",
         "Microsoft.NETCore.Platforms.nuspec",
@@ -15787,8 +15789,9 @@
       ]
     },
     "Microsoft.NETCore.Windows.ApiSets/1.0.1": {
-      "sha512": "SaToCvvsGMxTgtLv/BrFQ5IFMPRE1zpWbnqbpwykJa8W5XiX82CXI6K2o7yf5xS7EP6t/JzFLV0SIDuWpvBZVw==",
+      "sha512": "O3UBTjIj9mV66sZUHo/Ew5v0/QK1iGiWXqeQAW3M6kMbM/PN5e3ytZ0sOWakNUKaDOQLmBvGiIGe4BcJYVXpNw==",
       "type": "package",
+      "path": "Microsoft.NETCore.Windows.ApiSets/1.0.1",
       "files": [
         "Microsoft.NETCore.Windows.ApiSets.1.0.1.nupkg.sha512",
         "Microsoft.NETCore.Windows.ApiSets.nuspec",
@@ -15798,8 +15801,9 @@
       ]
     },
     "Microsoft.VisualBasic/10.0.1": {
-      "sha512": "HpNyOf/4Tp2lh4FyywB55VITk0SqVxEjDzsVDDyF1yafDN6Bq18xcHowzCPINyYHUTgGcEtmpYiRsFdSo0KKdQ==",
+      "sha512": "WKzJq+K1vt3f/0OFAsM0aer5DtkMEt41qgpEz4OHtyU7BCoRNyMwpztJCyWH5EPpFZHsFWDo/pP0l9M3t87Kvg==",
       "type": "package",
+      "path": "Microsoft.VisualBasic/10.0.1",
       "files": [
         "Microsoft.VisualBasic.10.0.1.nupkg.sha512",
         "Microsoft.VisualBasic.nuspec",
@@ -15840,8 +15844,9 @@
       ]
     },
     "Microsoft.Win32.Primitives/4.0.1": {
-      "sha512": "fQnBHO9DgcmkC9dYSJoBqo6sH1VJwJprUHh8F3hbcRlxiQiBUuTntdk8tUwV490OqC2kQUrinGwZyQHTieuXRA==",
+      "sha512": "jbev9iGVibb2wmLXrmusNq07eixcwQ0HI+Weci2Mg3yaUsnTo2eMSynMZhzFB8xEwqiFZJnGOewyfppT3/qjKw==",
       "type": "package",
+      "path": "Microsoft.Win32.Primitives/4.0.1",
       "files": [
         "Microsoft.Win32.Primitives.4.0.1.nupkg.sha512",
         "Microsoft.Win32.Primitives.nuspec",
@@ -15913,12 +15918,12 @@
         "tools/install.ps1"
       ]
     },
-    "PortableWebDavLibrary/0.5.1": {
-      "sha512": "WzEFvwrtqTMB0GFacjjbhwnPgyTzrsOLNTb7G9ms/Q+Ih6HpiUIL1d+BxqAaQN1pxfMegFoGXKRlILee7v1BMg==",
+    "PortableWebDavLibrary/0.6.1": {
+      "sha512": "959t6RbP1q/4PWQbjK9qVoX/sfGkBpMEltrWam7E3bWR925wrB1U3DMSI83jOjoTZdTfjYm6VO6kjxPaXbbkag==",
       "type": "package",
-      "path": "PortableWebDavLibrary/0.5.1",
+      "path": "PortableWebDavLibrary/0.6.1",
       "files": [
-        "PortableWebDavLibrary.0.5.1.nupkg.sha512",
+        "PortableWebDavLibrary.0.6.1.nupkg.sha512",
         "PortableWebDavLibrary.nuspec",
         "lib/DecaTec.WebDav.NetFx.dll",
         "lib/portable-Profile32/DecaTec.WebDav.Uwp.dll"
@@ -16585,8 +16590,9 @@
       ]
     },
     "runtime.native.System.IO.Compression/4.1.0": {
-      "sha512": "Ob7nvnJBox1aaB222zSVZSkf4WrebPG4qFscfK7vmD7P7NxoSxACQLtO7ytWpqXDn2wcd/+45+EAZ7xjaPip8A==",
+      "sha512": "RIfSfgkTyijeDoKM78kvlcbedvhxbI7b5cpmQppmbFx6FUCuvkKJLe7SHYGT3EmYkVvh5VCgKM4YtwRUT0AfEg==",
       "type": "package",
+      "path": "runtime.native.System.IO.Compression/4.1.0",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
@@ -16596,8 +16602,9 @@
       ]
     },
     "runtime.native.System.Security.Cryptography/4.0.0": {
-      "sha512": "2CQK0jmO6Eu7ZeMgD+LOFbNJSXHFVQbCJJkEyEwowh1SCgYnrn9W9RykMfpeeVGw7h4IBvYikzpGUlmZTUafJw==",
+      "sha512": "Nwt4+pFIQLMssWbdKtpgB22kXK4QFuuFJHD9UD5rVyQK82f5Id+MDakYQtGoMbY4ZKf6GDpQhXQwi15VqGVoyQ==",
       "type": "package",
+      "path": "runtime.native.System.Security.Cryptography/4.0.0",
       "files": [
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
@@ -16881,8 +16888,9 @@
       ]
     },
     "System.AppContext/4.1.0": {
-      "sha512": "3QjO4jNV7PdKkmQAVp9atA+usVnKRwI3Kx1nMwJ93T0LcQfx7pKAYk0nKz5wn1oP5iqlhZuy6RXOFdhr7rDwow==",
+      "sha512": "bjNxiWxt84pL4Tf0ag4vTabkEVw9j8FIX451fVmu8dArUSJqSB+BAeSEzpNQKah7V6ZTzvMynltvCB8WfWpoRg==",
       "type": "package",
+      "path": "System.AppContext/4.1.0",
       "files": [
         "System.AppContext.4.1.0.nupkg.sha512",
         "System.AppContext.nuspec",
@@ -16933,8 +16941,9 @@
       ]
     },
     "System.Buffers/4.0.0": {
-      "sha512": "msXumHfjjURSkvxUjYuq4N2ghHoRi2VpXcKMA7gK6ujQfU3vGpl+B6ld0ATRg+FZFpRyA6PgEPA+VlIkTeNf2w==",
+      "sha512": "AxBS3PdBJ0JyL7JWdyB1b7O6cs7AzGZskLKFwKyUdatgbyVqqSUKss7ZeAUlz1g/39Dzqe5SCwsFUx9ZY6bsSg==",
       "type": "package",
+      "path": "System.Buffers/4.0.0",
       "files": [
         "System.Buffers.4.0.0.nupkg.sha512",
         "System.Buffers.nuspec",
@@ -16945,8 +16954,9 @@
       ]
     },
     "System.Collections/4.0.11": {
-      "sha512": "YUJGz6eFKqS0V//mLt25vFGrrCvOnsXjlvFQs+KimpwNxug9x0Pzy4PlFMU3Q2IzqAa9G2L4LsK3+9vCBK7oTg==",
+      "sha512": "CTMYBEa+Gfl0oydYA7F0aaKQ5MsHGYpYNvGYyDtBu4kK6cor96Ha2Nm0iQhhB42oxgSjCpuaK/6U2NTn4q1dFQ==",
       "type": "package",
+      "path": "System.Collections/4.0.11",
       "files": [
         "System.Collections.4.0.11.nupkg.sha512",
         "System.Collections.nuspec",
@@ -17010,8 +17020,9 @@
       ]
     },
     "System.Collections.Concurrent/4.0.12": {
-      "sha512": "2gBcbb3drMLgxlI0fBfxMA31ec6AEyYCHygGse4vxceJan8mRIWeKJ24BFzN7+bi/NFTgdIgufzb94LWO5EERQ==",
+      "sha512": "FOHOqZthO4MXICnIgf4Wc+o9uqil3nOxxkky75v2rOcR8B5151szBBcHd8B/fxC/fSLM+8tb9yPj9pKuPPwVDw==",
       "type": "package",
+      "path": "System.Collections.Concurrent/4.0.12",
       "files": [
         "System.Collections.Concurrent.4.0.12.nupkg.sha512",
         "System.Collections.Concurrent.nuspec",
@@ -17075,8 +17086,9 @@
       ]
     },
     "System.Collections.Immutable/1.2.0": {
-      "sha512": "Cma8cBW6di16ZLibL8LYQ+cLjGzoKxpOTu/faZfDcx94ZjAGq6Nv5RO7+T1YZXqEXTZP9rt1wLVEONVpURtUqw==",
+      "sha512": "KGTp0F4pjND6L6kYwxGeabcLeXMyDo3bleXP4i/59XeYC7oalPsIDJUvEjPgDtsw2kgbhKhLPfn+ngibged6gg==",
       "type": "package",
+      "path": "System.Collections.Immutable/1.2.0",
       "files": [
         "System.Collections.Immutable.1.2.0.nupkg.sha512",
         "System.Collections.Immutable.nuspec",
@@ -17161,8 +17173,9 @@
       ]
     },
     "System.ComponentModel/4.0.1": {
-      "sha512": "oBZFnm7seFiVfugsIyOvQCWobNZs7FzqDV/B7tx20Ep/l3UUFCPDkdTnCNaJZTU27zjeODmy2C/cP60u3D4c9w==",
+      "sha512": "Q5C9A79liDFHumTorAk7XLfA1bGDayKyF+7kcmb/f1WaJAaCxnnh7/nkY2D2duAufXj/hreOiFxWtzQ0DuLCGQ==",
       "type": "package",
+      "path": "System.ComponentModel/4.0.1",
       "files": [
         "System.ComponentModel.4.0.1.nupkg.sha512",
         "System.ComponentModel.nuspec",
@@ -17217,8 +17230,9 @@
       ]
     },
     "System.ComponentModel.Annotations/4.1.0": {
-      "sha512": "rhnz80h8NnHJzoi0nbQJLRR2cJznyqG168q1bgoSpe5qpaME2SguXzuEzpY68nFCi2kBgHpbU4bRN2cP3unYRA==",
+      "sha512": "GhVF48cKxzBFCqoxFsf6g7Rw84YWAW7psgJRISjWkoP7HfXvxKoURRELFAo8XT8Wi8Mpjlgfi7mmcJGB7W6KYg==",
       "type": "package",
+      "path": "System.ComponentModel.Annotations/4.1.0",
       "files": [
         "System.ComponentModel.Annotations.4.1.0.nupkg.sha512",
         "System.ComponentModel.Annotations.nuspec",
@@ -17465,8 +17479,9 @@
       ]
     },
     "System.Diagnostics.Debug/4.0.11": {
-      "sha512": "w5U95fVKHY4G8ASs/K5iK3J5LY+/dLFd4vKejsnI/ZhBsWS9hQakfx3Zr7lRWKg4tAw9r4iktyvsTagWkqYCiw==",
+      "sha512": "SiI7UBPwjTsWz+RbK9zHfHJ0lQwiqdPiO/0H50N69cubfM8Lqnv5N4grO7DnpdutaHGV2qB1kLrmPeTwBtktdg==",
       "type": "package",
+      "path": "System.Diagnostics.Debug/4.0.11",
       "files": [
         "System.Diagnostics.Debug.4.0.11.nupkg.sha512",
         "System.Diagnostics.Debug.nuspec",
@@ -17530,8 +17545,9 @@
       ]
     },
     "System.Diagnostics.DiagnosticSource/4.0.0": {
-      "sha512": "YKglnq4BMTJxfcr6nuT08g+yJ0UxdePIHxosiLuljuHIUR6t4KhFsyaHOaOc1Ofqp0PUvJ0EmcgiEz6T7vEx3w==",
+      "sha512": "VZfej2zF3IBFPYc7DbrH5Dd0kMocsTtI1a8wvI0DV6HWA3vUNGjJXVYhIESD2WxtIEW0FYk6A65Et2CH04QqPg==",
       "type": "package",
+      "path": "System.Diagnostics.DiagnosticSource/4.0.0",
       "files": [
         "System.Diagnostics.DiagnosticSource.4.0.0.nupkg.sha512",
         "System.Diagnostics.DiagnosticSource.nuspec",
@@ -17585,8 +17601,9 @@
       ]
     },
     "System.Diagnostics.Tools/4.0.1": {
-      "sha512": "xBfJ8pnd4C17dWaC9FM6aShzbJcRNMChUMD42I6772KGGrqaFdumwhn9OdM68erj1ueNo3xdQ1EwiFjK5k8p0g==",
+      "sha512": "5j7H9L3NqUwGk034g3sf3quutpL3JpmzgqIKweQPZ0FC+iILukBNGUptoAM3Pd+7dUwmOqKotXgvYbDfG8GFSA==",
       "type": "package",
+      "path": "System.Diagnostics.Tools/4.0.1",
       "files": [
         "System.Diagnostics.Tools.4.0.1.nupkg.sha512",
         "System.Diagnostics.Tools.nuspec",
@@ -17639,8 +17656,9 @@
       ]
     },
     "System.Diagnostics.Tracing/4.1.0": {
-      "sha512": "vDN1PoMZCkkdNjvZLql592oYJZgS7URcJzJ7bxeBgGtx5UtR5leNm49VmfHGqIffX4FKacHbI3H6UyNSHQknBg==",
+      "sha512": "LUR+jq3qYFtqgryN4kj5Dg60D6AkZNIzHYxN1Uhme+/BWW6O2iZoJKBLkiw4awHmsSREtPMRhXRfWHAt77K1zA==",
       "type": "package",
+      "path": "System.Diagnostics.Tracing/4.1.0",
       "files": [
         "System.Diagnostics.Tracing.4.1.0.nupkg.sha512",
         "System.Diagnostics.Tracing.nuspec",
@@ -17726,8 +17744,9 @@
       ]
     },
     "System.Dynamic.Runtime/4.0.11": {
-      "sha512": "db34f6LHYM0U0JpE+sOmjar27BnqTVkbLJhgfwMpTdgTigG/Hna3m2MYVwnFzGGKnEJk2UXFuoVTr8WUbU91/A==",
+      "sha512": "TKNVObVEYYxt54INznN5daYtaGqTnPjkMZBqAj9RSUSvImScTc/QCMJhGALKxGLN+zlkO4Ni7uM5xBx4QPu9kw==",
       "type": "package",
+      "path": "System.Dynamic.Runtime/4.0.11",
       "files": [
         "System.Dynamic.Runtime.4.0.11.nupkg.sha512",
         "System.Dynamic.Runtime.nuspec",
@@ -17794,8 +17813,9 @@
       ]
     },
     "System.Globalization/4.0.11": {
-      "sha512": "B95h0YLEL2oSnwF/XjqSWKnwKOy/01VWkNlsCeMTFJLLabflpGV26nK164eRs5GiaRSBGpOxQ3pKoSnnyZN5pg==",
+      "sha512": "Zt1OF/6AGv5rNY9SQHdBkDEIp/NNadCQg7AR73Yi0AnGaWhcX//tIq30ZonmiPKkLFCUGxokHQ0pfsUlrGmEOA==",
       "type": "package",
+      "path": "System.Globalization/4.0.11",
       "files": [
         "System.Globalization.4.0.11.nupkg.sha512",
         "System.Globalization.nuspec",
@@ -17859,8 +17879,9 @@
       ]
     },
     "System.Globalization.Calendars/4.0.1": {
-      "sha512": "L1c6IqeQ88vuzC1P81JeHmHA8mxq8a18NUBNXnIY/BVb+TCyAaGIFbhpZt60h9FJNmisymoQkHEFSE9Vslja1Q==",
+      "sha512": "wdSEGuG2+y18owo1E5rg/BDyHVRclHv67GqU/3cFXpI+6hvn30O6o3FyWP/RCLZsV4R/jrFLKhj2cKnqlrDg4g==",
       "type": "package",
+      "path": "System.Globalization.Calendars/4.0.1",
       "files": [
         "System.Globalization.Calendars.4.0.1.nupkg.sha512",
         "System.Globalization.Calendars.nuspec",
@@ -17894,8 +17915,9 @@
       ]
     },
     "System.Globalization.Extensions/4.0.1": {
-      "sha512": "KKo23iKeOaIg61SSXwjANN7QYDr/3op3OWGGzDzz7mypx0Za0fZSeG0l6cco8Ntp8YMYkIQcAqlk8yhm5/Uhcg==",
+      "sha512": "fK1OyQLIvad8G1Py+j9RrILidvZ4Zrn32dsYFj58ajA/9mzzEkgc1nNmLSBQWQ1TA5Jn7bZ0q/Q8syvk9rZaGw==",
       "type": "package",
+      "path": "System.Globalization.Extensions/4.0.1",
       "files": [
         "System.Globalization.Extensions.4.0.1.nupkg.sha512",
         "System.Globalization.Extensions.nuspec",
@@ -17932,8 +17954,9 @@
       ]
     },
     "System.IO/4.1.0": {
-      "sha512": "3KlTJceQc3gnGIaHZ7UBZO26SHL1SHE4ddrmiwumFnId+CEHP+O8r386tZKaE6zlk5/mF8vifMBzHj9SaXN+mQ==",
+      "sha512": "Qcxiysr53/95okNK+urDSdVMLr56GMvOA5tchH2A837seaElJLbBw4xKF4pCU85FdHZNiGx+LSLX1PcVW9Vr7g==",
       "type": "package",
+      "path": "System.IO/4.1.0",
       "files": [
         "System.IO.4.1.0.nupkg.sha512",
         "System.IO.nuspec",
@@ -18078,8 +18101,9 @@
       ]
     },
     "System.IO.Compression.ZipFile/4.0.1": {
-      "sha512": "hBQYJzfTbQURF10nLhd+az2NHxsU6MU7AB8RUf4IolBP5lOAm4Luho851xl+CqslmhI5ZH/el8BlngEk4lBkaQ==",
+      "sha512": "MKKUTuoH6wpicZlzMYQVHft4a4AvVXs4THdes8M4Qnm6C+C88fOrr66xLvxOhrSjboPFDGgDThWoLMTNjmAYRg==",
       "type": "package",
+      "path": "System.IO.Compression.ZipFile/4.0.1",
       "files": [
         "System.IO.Compression.ZipFile.4.0.1.nupkg.sha512",
         "System.IO.Compression.ZipFile.nuspec",
@@ -18114,8 +18138,9 @@
       ]
     },
     "System.IO.FileSystem/4.0.1": {
-      "sha512": "IBErlVq5jOggAD69bg1t0pJcHaDbJbWNUZTPI96fkYWzwYbN6D9wRHMULLDd9dHsl7C2YsxXL31LMfPI1SWt8w==",
+      "sha512": "3pd5J2+c2kM4TBL0pHHcXV40biNb/H0cjCv0zkoH+5NPuVmdMaV5AVv8mu+lXrnHN1hcBC6EEPn31IwzmjQyhA==",
       "type": "package",
+      "path": "System.IO.FileSystem/4.0.1",
       "files": [
         "System.IO.FileSystem.4.0.1.nupkg.sha512",
         "System.IO.FileSystem.nuspec",
@@ -18149,8 +18174,9 @@
       ]
     },
     "System.IO.FileSystem.Primitives/4.0.1": {
-      "sha512": "kWkKD203JJKxJeE74p8aF8y4Qc9r9WQx4C0cHzHPrY3fv/L/IhWnyCHaFJ3H1QPOH6A93whlQ2vG5nHlBDvzWQ==",
+      "sha512": "dKehuQ1DqOsLLPgpaWi3egTb7W7SIfG0HdRAAHlZ2WBcNCXdaeGasq6fiS2yjH5d/WWxE2cc0Sv849YWelK5tg==",
       "type": "package",
+      "path": "System.IO.FileSystem.Primitives/4.0.1",
       "files": [
         "System.IO.FileSystem.Primitives.4.0.1.nupkg.sha512",
         "System.IO.FileSystem.Primitives.nuspec",
@@ -18219,8 +18245,9 @@
       ]
     },
     "System.IO.UnmanagedMemoryStream/4.0.1": {
-      "sha512": "wcq0kXcpfJwdl1Y4/ZjDk7Dhx5HdLyRYYWYmD8Nn8skoGYYQd2BQWbXwjWSczip8AL4Z57o2dWWXAl4aABAKiQ==",
+      "sha512": "DQpT2K89Qzn8hHeZ20FwlncWAWF+jDwqXzCXcGM8LPZUD09x1xdYrYLVy5gj9I1i9Ef1lGLWAmhJDDDNdHEC5g==",
       "type": "package",
+      "path": "System.IO.UnmanagedMemoryStream/4.0.1",
       "files": [
         "System.IO.UnmanagedMemoryStream.4.0.1.nupkg.sha512",
         "System.IO.UnmanagedMemoryStream.nuspec",
@@ -18255,8 +18282,9 @@
       ]
     },
     "System.Linq/4.1.0": {
-      "sha512": "bQ0iYFOQI0nuTnt+NQADns6ucV4DUvMdwN6CbkB1yj8i7arTGiTN5eok1kQwdnnNWSDZfIUySQY+J3d5KjWn0g==",
+      "sha512": "XPHRXBZbqBHf5k3SKcZsJqyCanyOXfT/kry5k/70d4/MQJieZ7h1DKddKxskxztNJs91a3E5lz7fqZT1Ph8m+w==",
       "type": "package",
+      "path": "System.Linq/4.1.0",
       "files": [
         "System.Linq.4.1.0.nupkg.sha512",
         "System.Linq.nuspec",
@@ -18324,8 +18352,9 @@
       ]
     },
     "System.Linq.Expressions/4.1.0": {
-      "sha512": "I+y02iqkgmCAyfbqOmSDOgqdZQ5tTj80Akm5BPSS8EeB0VGWdy6X1KCoYe8Pk6pwDoAKZUOdLVxnTJcExiv5zw==",
+      "sha512": "rqGxb2ijXC5mfd01TsNkad7/bs8be7qBlubYlZsdVtT9GYqYNMNC8anZqm/khhyVzjyPe+aTQoTIj8bRR6qeuA==",
       "type": "package",
+      "path": "System.Linq.Expressions/4.1.0",
       "files": [
         "System.Linq.Expressions.4.1.0.nupkg.sha512",
         "System.Linq.Expressions.nuspec",
@@ -18405,8 +18434,9 @@
       ]
     },
     "System.Linq.Parallel/4.0.1": {
-      "sha512": "J7XCa7n2cFn32uLbtceXfBFhgCk5M++50lylHKNbqTiJkw5y4Tglpi6amuJNPCvj9bLzNSI7rs1fi4joLMNRgg==",
+      "sha512": "3FeFyQ8jF8oxaFvU9Qa4gLepYz3s8cHpTKrAEIc5myZiFuAZfDT/Mg/FBziZplSq7GFsi+1PbUGIEsyXDatMUg==",
       "type": "package",
+      "path": "System.Linq.Parallel/4.0.1",
       "files": [
         "System.Linq.Parallel.4.0.1.nupkg.sha512",
         "System.Linq.Parallel.nuspec",
@@ -18459,8 +18489,9 @@
       ]
     },
     "System.Linq.Queryable/4.0.1": {
-      "sha512": "Yn/WfYe9RoRfmSLvUt2JerP0BTGGykCZkQPgojaxgzF2N0oPo+/AhB8TXOpdCcNlrG3VRtsamtK2uzsp3cqRVw==",
+      "sha512": "Go1trqKEpVZNGar/oS7d0KQFhathRcLJVpy7Bl2bAVy37OjenLkADmFMDjs7PHybXyallntv3xdrDu+C/oYc4g==",
       "type": "package",
+      "path": "System.Linq.Queryable/4.0.1",
       "files": [
         "System.Linq.Queryable.4.0.1.nupkg.sha512",
         "System.Linq.Queryable.nuspec",
@@ -18515,8 +18546,9 @@
       ]
     },
     "System.Net.Http/4.1.0": {
-      "sha512": "ULq9g3SOPVuupt+Y3U+A37coXzdNisB1neFCSKzBwo182u0RDddKJF8I5+HfyXqK6OhJPgeoAwWXrbiUXuRDsg==",
+      "sha512": "quHJXdAOivIXoCec2MzkBCIZfnmDU9JvTusWCyF85ezHJZAlwLwqUHWKOUz3EMwMCk8qvgneETmgpHGnNAhk4w==",
       "type": "package",
+      "path": "System.Net.Http/4.1.0",
       "files": [
         "System.Net.Http.4.1.0.nupkg.sha512",
         "System.Net.Http.nuspec",
@@ -18629,8 +18661,9 @@
       ]
     },
     "System.Net.NameResolution/4.0.0": {
-      "sha512": "JdqRdM1Qym3YehqdKIi5LHrpypP4JMfxKQSNCJ2z4WawkG0il+N3XfNeJOxll2XrTnG7WgYYPoeiu/KOwg0DQw==",
+      "sha512": "v6Vu4uuDPyqd88fhcfy4Ou/5vPLSt2FYFVaVhcmA7QaTgi3HJb4erihGgN47F8hJIgzAUP7z0xOz/OyVCz0Ijg==",
       "type": "package",
+      "path": "System.Net.NameResolution/4.0.0",
       "files": [
         "System.Net.NameResolution.4.0.0.nupkg.sha512",
         "System.Net.NameResolution.nuspec",
@@ -18740,8 +18773,9 @@
       ]
     },
     "System.Net.Primitives/4.0.11": {
-      "sha512": "hVvfl4405DRjA2408luZekbPhplJK03j2Y2lSfMlny7GHXlkByw1iLnc9mgKW0GdQn73vvMcWrWewAhylXA4Nw==",
+      "sha512": "yswyvdmCjIsBEPVJh6i4motaUbUu/75tJ7GM2hvOKkgK29r5oTEFF3HFbWkW4c0/5N4wA05/mKi6GbnbxSOF+w==",
       "type": "package",
+      "path": "System.Net.Primitives/4.0.11",
       "files": [
         "System.Net.Primitives.4.0.11.nupkg.sha512",
         "System.Net.Primitives.nuspec",
@@ -18816,8 +18850,9 @@
       ]
     },
     "System.Net.Requests/4.0.11": {
-      "sha512": "vxGt7C0cZixN+VqoSW4Yakc1Y9WknmxauDqzxgpw/FnBdz4kQNN51l4wxdXX5VY1xjqy//+G+4CvJWp1+f+y6Q==",
+      "sha512": "LsJkl5FGce+FdMGExEGCZpEaqrpIooilX3jkQkZXHD5PGvEjuGY8GC468c0oJGosbk0p8M9gWZCLwbNoR047Yw==",
       "type": "package",
+      "path": "System.Net.Requests/4.0.11",
       "files": [
         "System.Net.Requests.4.0.11.nupkg.sha512",
         "System.Net.Requests.nuspec",
@@ -18896,8 +18931,9 @@
       ]
     },
     "System.Net.Sockets/4.1.0": {
-      "sha512": "xAz0N3dAV/aR/9g8r0Y5oEqU1JRsz29F5EGb/WVHmX3jVSLqi2/92M5hTad2aNWovruXrJpJtgZ9fccPMG9uSw==",
+      "sha512": "CUYaP4Y7JXz36myO3KEPBWCkyRkZypB5EvVcXqA+eTMA92zrLB+RMSo8LZgEArWPB17LVHobp2MkFXuUtwHdGg==",
       "type": "package",
+      "path": "System.Net.Sockets/4.1.0",
       "files": [
         "System.Net.Sockets.4.1.0.nupkg.sha512",
         "System.Net.Sockets.nuspec",
@@ -18931,8 +18967,9 @@
       ]
     },
     "System.Net.WebHeaderCollection/4.0.1": {
-      "sha512": "XX2TIAN+wBSAIV51BU2FvvXMdstUa8b0FBSZmDWjZdwUMmggQSifpTOZ5fNH20z9ZCg2fkV1L5SsZnpO2RQDRQ==",
+      "sha512": "hs73Im2Q7woTH50T6pFWMvPZvyoEF+7AQJY+rzk/xKIxZV0OIzQorO0Fnwa/wkWHv/vHXqFSf5/mHFk7lTCAxA==",
       "type": "package",
+      "path": "System.Net.WebHeaderCollection/4.0.1",
       "files": [
         "System.Net.WebHeaderCollection.4.0.1.nupkg.sha512",
         "System.Net.WebHeaderCollection.nuspec",
@@ -19042,8 +19079,9 @@
       ]
     },
     "System.Numerics.Vectors/4.1.1": {
-      "sha512": "Ex1NSKycC2wi5XBMWUGWPc3lumh6OQWFFmmpZFZz0oLht5lQ+wWPHVZumOrMJuckfUiVMd4p67BrkBos8lcF+Q==",
+      "sha512": "VIPNAVnXoZAFieaZ413vft6CrvpLsxRuZbl+wbXLYZAPBuyZO6eYfsNT44UjZWBCc9GFpms9K223LR6Z95DfGA==",
       "type": "package",
+      "path": "System.Numerics.Vectors/4.1.1",
       "files": [
         "System.Numerics.Vectors.4.1.1.nupkg.sha512",
         "System.Numerics.Vectors.nuspec",
@@ -19085,8 +19123,9 @@
       ]
     },
     "System.ObjectModel/4.0.12": {
-      "sha512": "tAgJM1xt3ytyMoW4qn4wIqgJYm7L7TShRZG4+Q4Qsi2PCcj96pXN7nRywS9KkB3p/xDUjc2HSwP9SROyPYDYKQ==",
+      "sha512": "VQ/GDF/Ol+GEAeJGzmliGOlLjoGO4zY0zwLZrB09Ra44lIFSgnRvRR/xrzP49B1I/g57JT4zmfxTiF1TO7sS+Q==",
       "type": "package",
+      "path": "System.ObjectModel/4.0.12",
       "files": [
         "System.ObjectModel.4.0.12.nupkg.sha512",
         "System.ObjectModel.nuspec",
@@ -19190,8 +19229,9 @@
       ]
     },
     "System.Reflection/4.1.0": {
-      "sha512": "JCKANJ0TI7kzoQzuwB/OoJANy1Lg338B6+JVacPl4TpUwi3cReg3nMLplMq2uqYfHFQpKIlHAUVAJlImZz/4ng==",
+      "sha512": "ySVK6mDLLylpzZjw2TfpduHExRTxVZhf7F4EhntQIjDG6v8U4HTg7vNYVLy1Kd/q9BUXCA9UWjxsgUO3YF0XnA==",
       "type": "package",
+      "path": "System.Reflection/4.1.0",
       "files": [
         "System.Reflection.4.1.0.nupkg.sha512",
         "System.Reflection.nuspec",
@@ -19308,8 +19348,9 @@
       ]
     },
     "System.Reflection.DispatchProxy/4.0.1": {
-      "sha512": "GPPgWoSxQEU3aCKSOvsAc1dhTTi4iq92PUVEVfnGPGwqCf6synaAJGYLKMs5E3CuRfel8ufACWUijXqDpOlGrA==",
+      "sha512": "WCpp5zZR7515OZ3/QgxCy+EuWagQTuq4WgregoiC9tN/QvztWXMgrVdq378OqNXESpcFSEn+jhUAy1prKbZNCA==",
       "type": "package",
+      "path": "System.Reflection.DispatchProxy/4.0.1",
       "files": [
         "System.Reflection.DispatchProxy.4.0.1.nupkg.sha512",
         "System.Reflection.DispatchProxy.nuspec",
@@ -19343,8 +19384,9 @@
       ]
     },
     "System.Reflection.Emit/4.0.1": {
-      "sha512": "P2wqAj72fFjpP6wb9nSfDqNBMab+2ovzSDzUZK7MVIm54tBJEPr9jWfSjjoTpPwj1LeKcmX3vr0ttyjSSFM47g==",
+      "sha512": "F1ypA4Xdgn631MALr4IUuLyNQ9wUUdLabrubtuW/KX4rcqMSlrDBr/6MSnrbc77A/Zaq20lWz9cxYFBvOvcpog==",
       "type": "package",
+      "path": "System.Reflection.Emit/4.0.1",
       "files": [
         "System.Reflection.Emit.4.0.1.nupkg.sha512",
         "System.Reflection.Emit.nuspec",
@@ -19372,8 +19414,9 @@
       ]
     },
     "System.Reflection.Emit.ILGeneration/4.0.1": {
-      "sha512": "Ov6dU8Bu15Bc7zuqttgHF12J5lwSWyTf1S+FJouUXVMSqImLZzYaQ+vRr1rQ0OZ0HqsrwWl4dsKHELckQkVpgA==",
+      "sha512": "UKWHiIgVSe+fWFI43uGOJdZQTZSFONZhOqSrfqTOjBBSZ0AXPPFz9+G/ryNMLJolEXfLw5DK2AJFEDtbc3hLOw==",
       "type": "package",
+      "path": "System.Reflection.Emit.ILGeneration/4.0.1",
       "files": [
         "System.Reflection.Emit.ILGeneration.4.0.1.nupkg.sha512",
         "System.Reflection.Emit.ILGeneration.nuspec",
@@ -19402,8 +19445,9 @@
       ]
     },
     "System.Reflection.Emit.Lightweight/4.0.1": {
-      "sha512": "sSzHHXueZ5Uh0OLpUQprhr+ZYJrLPA2Cmr4gn0wj9+FftNKXx8RIMKvO9qnjk2ebPYUjZ+F2ulGdPOsvj+MEjA==",
+      "sha512": "I6SgTbnHu4bHeOoaTj/LBovoO1QsBi8CFOSQqzHeWLC5naKWVzIilqKtFv9GuFPXLanlNbDoKyQzORZ7LL8yDQ==",
       "type": "package",
+      "path": "System.Reflection.Emit.Lightweight/4.0.1",
       "files": [
         "System.Reflection.Emit.Lightweight.4.0.1.nupkg.sha512",
         "System.Reflection.Emit.Lightweight.nuspec",
@@ -19432,8 +19476,9 @@
       ]
     },
     "System.Reflection.Extensions/4.0.1": {
-      "sha512": "GYrtRsZcMuHF3sbmRHfMYpvxZoIN2bQGrYGerUiWLEkqdEUQZhH3TRSaC/oI4wO0II1RKBPlpIa1TOMxIcOOzQ==",
+      "sha512": "QeP4oeD6vFhYObPJkd+eZtBmrmQepA80VuP9V0f3kPvAQ5RupXSLJzEOx3Swq01WFoxj3sDHXu15G4nkEXaqgg==",
       "type": "package",
+      "path": "System.Reflection.Extensions/4.0.1",
       "files": [
         "System.Reflection.Extensions.4.0.1.nupkg.sha512",
         "System.Reflection.Extensions.nuspec",
@@ -19486,8 +19531,9 @@
       ]
     },
     "System.Reflection.Metadata/1.3.0": {
-      "sha512": "jMSCxA4LSyKBGRDm/WtfkO03FkcgRzHxwvQRib1bm2GZ8ifKM1MX1al6breGCEQK280mdl9uQS7JNPXRYk90jw==",
+      "sha512": "sOt2tPwTTseNLt888hl4ioAKTz3vimaKUNcnv4gGLE3Uv/H3ymFL3oyhugTZv2xG88qfUEUj+iuloXiVqwOGeA==",
       "type": "package",
+      "path": "System.Reflection.Metadata/1.3.0",
       "files": [
         "System.Reflection.Metadata.1.3.0.nupkg.sha512",
         "System.Reflection.Metadata.nuspec",
@@ -19500,8 +19546,9 @@
       ]
     },
     "System.Reflection.Primitives/4.0.1": {
-      "sha512": "4inTox4wTBaDhB7V3mPvp9XlCbeGYWVEM9/fXALd52vNEAVisc1BoVWQPuUuD0Ga//dNbA/WeMy9u9mzLxGTHQ==",
+      "sha512": "TgHCqDrMwJZgqaaY0r7g8jsNOTrIauKmS12QcW8fufvbh9yNlT3MVQ6HV4TKSNWPcRNll8/zvvHe3V8uRMKccg==",
       "type": "package",
+      "path": "System.Reflection.Primitives/4.0.1",
       "files": [
         "System.Reflection.Primitives.4.0.1.nupkg.sha512",
         "System.Reflection.Primitives.nuspec",
@@ -19554,8 +19601,9 @@
       ]
     },
     "System.Reflection.TypeExtensions/4.1.0": {
-      "sha512": "tsQ/ptQ3H5FYfON8lL4MxRk/8kFyE0A+tGPXmVP967cT/gzLHYxIejIYSxp4JmIeFHVP78g/F2FE1mUUTbDtrg==",
+      "sha512": "pnB3aGHFqGqp4Q/A5ZOiFaQcjfzyLCDnvrQwmobK4ET/Abc7zDUaB8f6q6DpipsvQTAcSwNJDKkd1TANcK1ahg==",
       "type": "package",
+      "path": "System.Reflection.TypeExtensions/4.1.0",
       "files": [
         "System.Reflection.TypeExtensions.4.1.0.nupkg.sha512",
         "System.Reflection.TypeExtensions.nuspec",
@@ -19605,8 +19653,9 @@
       ]
     },
     "System.Resources.ResourceManager/4.0.1": {
-      "sha512": "TxwVeUNoTgUOdQ09gfTjvW411MF+w9MBYL7AtNVc+HtBCFlutPLhUCdZjNkjbhj3bNQWMdHboF0KIWEOjJssbA==",
+      "sha512": "3vGylyNdXQg8OCTBlPfDAtdBVy1ikShoGEEjNp6MyXqffiGX8VyABdzJVpRa9BBJA+rrTdxNEn9ginALKzh3RQ==",
       "type": "package",
+      "path": "System.Resources.ResourceManager/4.0.1",
       "files": [
         "System.Resources.ResourceManager.4.0.1.nupkg.sha512",
         "System.Resources.ResourceManager.nuspec",
@@ -19659,8 +19708,9 @@
       ]
     },
     "System.Runtime/4.1.0": {
-      "sha512": "v6c/4Yaa9uWsq+JMhnOFewrYkgdNHNG2eMKuNqRn8P733rNXeRCGvV5FkkjBXn2dbVkPXOsO0xjsEeM1q2zC0g==",
+      "sha512": "tdSWPnea2RBmX6GDeOmLGjUIn7e5eNmkfVfKtxCFTTrPF0kKoVVI71R1EwL/FAAUyog8Jbrx/7oLgT7L+v4USQ==",
       "type": "package",
+      "path": "System.Runtime/4.1.0",
       "files": [
         "System.Runtime.4.1.0.nupkg.sha512",
         "System.Runtime.nuspec",
@@ -19748,8 +19798,9 @@
       ]
     },
     "System.Runtime.Extensions/4.1.0": {
-      "sha512": "CUOHjTT/vgP0qGW22U4/hDlOqXmcPq5YicBaXdUR2UiUoLwBT+olO6we4DVbq57jeX5uXH2uerVZhf0qGj+sVQ==",
+      "sha512": "GI4e+TzkgLAOqd5ATuILGwe8J6vyWv1UYbXdxlLVWhsW1q7+TsrJ2cupIuBB7nNQQvSkB953skC6bVyaQMs9nA==",
       "type": "package",
+      "path": "System.Runtime.Extensions/4.1.0",
       "files": [
         "System.Runtime.Extensions.4.1.0.nupkg.sha512",
         "System.Runtime.Extensions.nuspec",
@@ -19826,8 +19877,9 @@
       ]
     },
     "System.Runtime.Handles/4.0.1": {
-      "sha512": "nCJvEKguXEvk2ymk1gqj625vVnlK3/xdGzx0vOKicQkoquaTBJTP13AIYkocSUwHCLNBwUbXTqTWGDxBTWpt7g==",
+      "sha512": "+VYuCoS3WTbKtpfJ/1gp259MkawdGyRHDM1m8BiSDQ+qw3llAYGfAdol9UHTQ6z5kUa0ZcF5F6llTLXa+/gphA==",
       "type": "package",
+      "path": "System.Runtime.Handles/4.0.1",
       "files": [
         "System.Runtime.Handles.4.0.1.nupkg.sha512",
         "System.Runtime.Handles.nuspec",
@@ -19861,8 +19913,9 @@
       ]
     },
     "System.Runtime.InteropServices/4.1.0": {
-      "sha512": "16eu3kjHS633yYdkjwShDHZLRNMKVi/s0bY8ODiqJ2RfMhDMAwxZaUaWVnZ2P71kr/or+X9o/xFWtNqz8ivieQ==",
+      "sha512": "3icvo/7SrMLclSjzt9qUi7zbwgA8+50ygz0wmtRsorhUFARV5XgG0FKXoAg0ss/P68I8YTeEgNIOavlw447CoQ==",
       "type": "package",
+      "path": "System.Runtime.InteropServices/4.1.0",
       "files": [
         "System.Runtime.InteropServices.4.1.0.nupkg.sha512",
         "System.Runtime.InteropServices.nuspec",
@@ -19994,8 +20047,9 @@
       ]
     },
     "System.Runtime.Numerics/4.0.1": {
-      "sha512": "+XbKFuzdmLP3d1o9pdHu2nxjNr2OEPqGzKeegPLCUMM71a0t50A/rOcIRmGs9wR7a8KuHX6hYs/7/TymIGLNqg==",
+      "sha512": "UdsaQjWYDt/h5So+MXpgRH8JXl6iknXcTDoNafk532uLoEWeEfZhnrC95vmmZLlEkxmaGufMf6DmnM9GQGbrig==",
       "type": "package",
+      "path": "System.Runtime.Numerics/4.0.1",
       "files": [
         "System.Runtime.Numerics.4.0.1.nupkg.sha512",
         "System.Runtime.Numerics.nuspec",
@@ -20335,8 +20389,9 @@
       ]
     },
     "System.Security.Claims/4.0.1": {
-      "sha512": "4Jlp0OgJLS/Voj1kyFP6MJlIYp3crgfH8kNQk2p7+4JYfc1aAmh9PZyAMMbDhuoolGNtux9HqSOazsioRiDvCw==",
+      "sha512": "VxFpvlf81w8NzPYew8+PlQfke9z8XMsr5b2Ez56YaHu3fVkwu27WIgoGcVctHdZzzhbjHAA/rw4oGgokA3IIJA==",
       "type": "package",
+      "path": "System.Security.Claims/4.0.1",
       "files": [
         "System.Security.Claims.4.0.1.nupkg.sha512",
         "System.Security.Claims.nuspec",
@@ -20371,8 +20426,9 @@
       ]
     },
     "System.Security.Cryptography.Algorithms/4.2.0": {
-      "sha512": "8JQFxbLVdrtIOKMDN38Fn0GWnqYZw/oMlwOUG/qz1jqChvyZlnUmu+0s7wLx7JYua/nAXoESpHA3iw11QFWhXg==",
+      "sha512": "Cl2hIZYSxgkVenjwLjlkFwq+yY1Ze8DaGH3LPt3geYqDmlHPOy2DZMDlPMEPT5KWf26XMU4MembFJsAw1+MFmw==",
       "type": "package",
+      "path": "System.Security.Cryptography.Algorithms/4.2.0",
       "files": [
         "System.Security.Cryptography.Algorithms.4.2.0.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec",
@@ -20408,8 +20464,9 @@
       ]
     },
     "System.Security.Cryptography.Cng/4.2.0": {
-      "sha512": "cUJ2h+ZvONDe28Szw3st5dOHdjndhJzQ2WObDEXAWRPEQBtVItVoxbXM/OEsTthl3cNn2dk2k0I3y45igCQcLw==",
+      "sha512": "CRi0KrLPUBqnjDIRGNU03qwkzNwZGlzw42P+UKTmDLFA8CH2Y+SB5Sx+6rUINN/fJW9c3qN+LQpxZr+AZRNeVA==",
       "type": "package",
+      "path": "System.Security.Cryptography.Cng/4.2.0",
       "files": [
         "System.Security.Cryptography.Cng.4.2.0.nupkg.sha512",
         "System.Security.Cryptography.Cng.nuspec",
@@ -20433,8 +20490,9 @@
       ]
     },
     "System.Security.Cryptography.Encoding/4.0.0": {
-      "sha512": "FbKgE5MbxSQMPcSVRgwM6bXN3GtyAh04NkV8E5zKCBE26X0vYW0UtTa2FIgkH33WVqBVxRgxljlVYumWtU+HcQ==",
+      "sha512": "NhOeBOCsosdk1xjK1wkOm8+RxHG33acB/6hOZGMMOZlgJ9dGhedWdYzhYePdp9bq1+UKRRrK/1QR2QhBeSMJ9Q==",
       "type": "package",
+      "path": "System.Security.Cryptography.Encoding/4.0.0",
       "files": [
         "System.Security.Cryptography.Encoding.4.0.0.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec",
@@ -20471,8 +20529,9 @@
       ]
     },
     "System.Security.Cryptography.Primitives/4.0.0": {
-      "sha512": "Wkd7QryWYjkQclX0bngpntW5HSlMzeJU24UaLJQ7YTfI8ydAVAaU2J+HXLLABOVJlKTVvAeL0Aj39VeTe7L+oA==",
+      "sha512": "77crS5k5DX7z+Gg7gURe5Bltey6SXX4MfVL5xl5SSRu7IGymCE7sRqw55f2iEykeq5E3pPYvMBY1rUzRU16Hig==",
       "type": "package",
+      "path": "System.Security.Cryptography.Primitives/4.0.0",
       "files": [
         "System.Security.Cryptography.Primitives.4.0.0.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec",
@@ -20497,8 +20556,9 @@
       ]
     },
     "System.Security.Cryptography.X509Certificates/4.1.0": {
-      "sha512": "4HEfsQIKAhA1+ApNn729Gi09zh+lYWwyIuViihoMDWp1vQnEkL2ct7mAbhBlLYm+x/L4Rr/pyGge1lIY635e0w==",
+      "sha512": "fkE0Fx+4YPp988gm7kISiZAt4B2K7JMa7RtyY1fVUQedO4vbfXQtR4vzvu4u8p6vIe5+sfqU7h2AvqAL9Tjuhg==",
       "type": "package",
+      "path": "System.Security.Cryptography.X509Certificates/4.1.0",
       "files": [
         "System.Security.Cryptography.X509Certificates.4.1.0.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec",
@@ -20550,8 +20610,9 @@
       ]
     },
     "System.Security.Principal/4.0.1": {
-      "sha512": "On+SKhXY5rzxh/S8wlH1Rm0ogBlu7zyHNxeNBiXauNrhHRXAe9EuX8Yl5IOzLPGU5Z4kLWHMvORDOCG8iu9hww==",
+      "sha512": "/Lwn1zfpG8HVLwAjPVcWFurM7GLOxLvNvuwU7ExFlbPsdnk7EXEN9Ff4/mXYOCma6B5mSxm+cO52kZYsmTJA+Q==",
       "type": "package",
+      "path": "System.Security.Principal/4.0.1",
       "files": [
         "System.Security.Principal.4.0.1.nupkg.sha512",
         "System.Security.Principal.nuspec",
@@ -20908,8 +20969,9 @@
       ]
     },
     "System.Text.Encoding/4.0.11": {
-      "sha512": "U3gGeMlDZXxCEiY4DwVLSacg+DFWCvoiX+JThA/rvw37Sqrku7sEFeVBBBMBnfB6FeZHsyDx85HlKL19x0HtZA==",
+      "sha512": "+BsiCYLs3KxRH9HyWTUjhen4F9BolPv4ZZHRcbQUrsWA8LuMkHEqAw5ABmbmsGNG37OBmBg0iIP7kokibm2lww==",
       "type": "package",
+      "path": "System.Text.Encoding/4.0.11",
       "files": [
         "System.Text.Encoding.4.0.11.nupkg.sha512",
         "System.Text.Encoding.nuspec",
@@ -20973,8 +21035,9 @@
       ]
     },
     "System.Text.Encoding.CodePages/4.0.1": {
-      "sha512": "h4z6rrA/hxWf4655D18IIZ0eaLRa3tQC/j+e26W+VinIHY0l07iEXaAvO0YSYq3MvCjMYy8Zs5AdC1sxNQOB7Q==",
+      "sha512": "pk7/3y+pNRIP5I1sHn8GUwTyxLAECPYjFL2fd6rIwrpDov4HtkktbHvgC7BCfA9G08Y+CGIKxUN80n4dDQ7ehg==",
       "type": "package",
+      "path": "System.Text.Encoding.CodePages/4.0.1",
       "files": [
         "System.Text.Encoding.CodePages.4.0.1.nupkg.sha512",
         "System.Text.Encoding.CodePages.nuspec",
@@ -21009,8 +21072,9 @@
       ]
     },
     "System.Text.Encoding.Extensions/4.0.11": {
-      "sha512": "jtbiTDtvfLYgXn8PTfWI+SiBs51rrmO4AAckx4KR6vFK9Wzf6tI8kcRdsYQNwriUeQ1+CtQbM1W4cMbLXnj/OQ==",
+      "sha512": "wEp2zrc4A5kQIYUQtqWu7eNWsoIh7IidBgjFtiQiQ5yz1P4Wcdrutk56v8BArWR+s+zA8kqK0/Lf29eKwAkpBQ==",
       "type": "package",
+      "path": "System.Text.Encoding.Extensions/4.0.11",
       "files": [
         "System.Text.Encoding.Extensions.4.0.11.nupkg.sha512",
         "System.Text.Encoding.Extensions.nuspec",
@@ -21074,8 +21138,9 @@
       ]
     },
     "System.Text.RegularExpressions/4.1.0": {
-      "sha512": "i88YCXpRTjCnoSQZtdlHkAOx4KNNik4hMy83n0+Ftlb7jvV6ZiZWMpnEZHhjBp6hQVh8gWd/iKNPzlPF7iyA2g==",
+      "sha512": "lzqn1AkYlDqUrHc/9yV4R+0Yz99B9OwRuwTxhWGOrQ5rHeyPm3fP7XueZpqUTG/eZzQYNbBIv62l0h1711wRYg==",
       "type": "package",
+      "path": "System.Text.RegularExpressions/4.1.0",
       "files": [
         "System.Text.RegularExpressions.4.1.0.nupkg.sha512",
         "System.Text.RegularExpressions.nuspec",
@@ -21154,8 +21219,9 @@
       ]
     },
     "System.Threading/4.0.11": {
-      "sha512": "N+3xqIcg3VDKyjwwCGaZ9HawG9aC6cSDI+s7ROma310GQo8vilFZa86hqKppwTHleR/G0sfOzhvgnUxWCR/DrQ==",
+      "sha512": "xHrdvmOVmmizFtwV5yg6zZ9ZLWRKi4gKTrPbtpW5fs4Rc5SOi44zaFRMqhtCipYjh7i5JT6A4d0KLKlgVXBdKw==",
       "type": "package",
+      "path": "System.Threading/4.0.11",
       "files": [
         "System.Threading.4.0.11.nupkg.sha512",
         "System.Threading.nuspec",
@@ -21222,8 +21288,9 @@
       ]
     },
     "System.Threading.Overlapped/4.0.1": {
-      "sha512": "f7aLuLkBoCQM2kng7zqLFBXz9Gk48gDK8lk1ih9rH/1arJJzZK9gJwNvPDhL6Ps/l6rwOr8jw+4FCHL0KKWiEg==",
+      "sha512": "qyHH13Gfnq55uqnY55V9/bRnLBkfb/fzu1krBtUgEV1Ylk1B4EGEwZxfmIQQXiDMQkQfsDgfNXa+GaCqdzi3ww==",
       "type": "package",
+      "path": "System.Threading.Overlapped/4.0.1",
       "files": [
         "System.Threading.Overlapped.4.0.1.nupkg.sha512",
         "System.Threading.Overlapped.nuspec",
@@ -21249,8 +21316,9 @@
       ]
     },
     "System.Threading.Tasks/4.0.11": {
-      "sha512": "k1S4Gc6IGwtHGT8188RSeGaX86Qw/wnrgNLshJvsdNUOPP9etMmo8S07c+UlOAx4K/xLuN9ivA1bD0LVurtIxQ==",
+      "sha512": "XqMpUqIV+svqQQjrWiyLNMXJRlbau+pES9rOcf8+HYkEnvLyv5am6D4equ5ndvrvbBVqORwX0Q8u7807tI9ZGQ==",
       "type": "package",
+      "path": "System.Threading.Tasks/4.0.11",
       "files": [
         "System.Threading.Tasks.4.0.11.nupkg.sha512",
         "System.Threading.Tasks.nuspec",
@@ -21314,8 +21382,9 @@
       ]
     },
     "System.Threading.Tasks.Dataflow/4.6.0": {
-      "sha512": "2hRjGu2r2jxRZ55wmcHO/WbdX+YAOz9x6FE8xqkHZgPaoFMKQZRe9dk8xTZIas8fRjxRmzawnTEWIrhlM+Un7w==",
+      "sha512": "49AYr/7GRg7+VD60fjlEt1osaahWapjqi+fZXrFWUGd2DtA5J95J52teaib0Jrojq2t1V5j8JYwObbG7MKCijw==",
       "type": "package",
+      "path": "System.Threading.Tasks.Dataflow/4.6.0",
       "files": [
         "System.Threading.Tasks.Dataflow.4.6.0.nupkg.sha512",
         "System.Threading.Tasks.Dataflow.nuspec",
@@ -21328,8 +21397,9 @@
       ]
     },
     "System.Threading.Tasks.Extensions/4.0.0": {
-      "sha512": "pH4FZDsZQ/WmgJtN4LWYmRdJAEeVkyriSwrv2Teoe5FOU0Yxlb6II6GL8dBPOfRmutHGATduj3ooMt7dJ2+i+w==",
+      "sha512": "zuE/75a+0nuTu+3z+xJUNNuv/wHgqM8AvnM4vybML9c6UJVR8pjRowt4G6VXQjnY77LRpxcpXmkAJA+JCok6iQ==",
       "type": "package",
+      "path": "System.Threading.Tasks.Extensions/4.0.0",
       "files": [
         "System.Threading.Tasks.Extensions.4.0.0.nupkg.sha512",
         "System.Threading.Tasks.Extensions.nuspec",
@@ -21342,8 +21412,9 @@
       ]
     },
     "System.Threading.Tasks.Parallel/4.0.1": {
-      "sha512": "7Pc9t25bcynT9FpMvkUw4ZjYwUiGup/5cJFW72/5MgCG+np2cfVUMdh29u8d7onxX7d8PS3J+wL73zQRqkdrSA==",
+      "sha512": "3/Cq8pJpiE1js2x1o2Lv07dss7rc+ySCN8N3lcI+MoNY5VjUXz3MJOFf54lJBevaovw6K5CmShpYh6RhVd4a/Q==",
       "type": "package",
+      "path": "System.Threading.Tasks.Parallel/4.0.1",
       "files": [
         "System.Threading.Tasks.Parallel.4.0.1.nupkg.sha512",
         "System.Threading.Tasks.Parallel.nuspec",
@@ -21396,8 +21467,9 @@
       ]
     },
     "System.Threading.Timer/4.0.1": {
-      "sha512": "saGfUV8uqVW6LeURiqxcGhZ24PzuRNaUBtbhVeuUAvky1naH395A/1nY0P2bWvrw/BreRtIB/EzTDkGBpqCwEw==",
+      "sha512": "ppKa21mafQqgIo/XIm9tMD0dN/ok3J4N1SAvlvze4W/TChpaewTQZFxQbjanThfa31hNihRKYkV7aX2AbgANnQ==",
       "type": "package",
+      "path": "System.Threading.Timer/4.0.1",
       "files": [
         "System.Threading.Timer.4.0.1.nupkg.sha512",
         "System.Threading.Timer.nuspec",
@@ -21448,8 +21520,9 @@
       ]
     },
     "System.Xml.ReaderWriter/4.0.11": {
-      "sha512": "ZIiLPsf67YZ9zgr31vzrFaYQqxRPX9cVHjtPSnmx4eN6lbS/yEyYNr2vs1doGDEscF0tjCZFsk9yUg1sC9e8tg==",
+      "sha512": "BZioPCkaIbXFZToxCu88G6n8HIVosUkNWScNJN+/Ea2wFfwBKVlnYT+ZjRCYDCn0TifVfUMqYtKaSFkVg9LAKA==",
       "type": "package",
+      "path": "System.Xml.ReaderWriter/4.0.11",
       "files": [
         "System.Xml.ReaderWriter.4.0.11.nupkg.sha512",
         "System.Xml.ReaderWriter.nuspec",
@@ -21515,8 +21588,9 @@
       ]
     },
     "System.Xml.XDocument/4.0.11": {
-      "sha512": "Mk2mKmPi0nWaoiYeotq1dgeNK1fqWh61+EK+w4Wu8SWuTYLzpUnschb59bJtGywaPq7SmTuPf44wrXRwbIrukg==",
+      "sha512": "ji/wdUuVEd2SR/cL+2z1S/StXwsZlE1DiGVp/xXP5DnVNkDlzwqe+8f5U896yuMDcOy4zZMi+wUrOWCTAtGiaw==",
       "type": "package",
+      "path": "System.Xml.XDocument/4.0.11",
       "files": [
         "System.Xml.XDocument.4.0.11.nupkg.sha512",
         "System.Xml.XDocument.nuspec",
@@ -21582,8 +21656,9 @@
       ]
     },
     "System.Xml.XmlDocument/4.0.1": {
-      "sha512": "2eZu6IP+etFVBBFUFzw2w6J21DqIN5eL9Y8r8JfJWUmV28Z5P0SNU01oCisVHQgHsDhHPnmq2s1hJrJCFZWloQ==",
+      "sha512": "TNzRsB45/NLbgh4dPQMrScSS9S49v0YZKVpHfX+pxo1Cef2UQs0pF95ohd9Fau/SthkxxhBMHZitvEaC2uoLqg==",
       "type": "package",
+      "path": "System.Xml.XmlDocument/4.0.1",
       "files": [
         "System.Xml.XmlDocument.4.0.1.nupkg.sha512",
         "System.Xml.XmlDocument.nuspec",

--- a/NextcloudClient/project.json
+++ b/NextcloudClient/project.json
@@ -2,7 +2,7 @@
   "supports": {},
   "dependencies": {
     "Newtonsoft.Json": "9.0.1",
-    "PortableWebDavLibrary": "0.5.1"
+    "PortableWebDavLibrary": "0.6.1"
   },
   "frameworks": {
     ".NETCore,Version=v4.5.1": {}

--- a/NextcloudClient/project.lock.json
+++ b/NextcloudClient/project.lock.json
@@ -12,7 +12,7 @@
           "lib/portable-net45+wp80+win8+wpa81/Newtonsoft.Json.dll": {}
         }
       },
-      "PortableWebDavLibrary/0.5.1": {
+      "PortableWebDavLibrary/0.6.1": {
         "type": "package",
         "compile": {
           "lib/portable-Profile32/DecaTec.WebDav.Uwp.dll": {}
@@ -48,12 +48,12 @@
         "tools/install.ps1"
       ]
     },
-    "PortableWebDavLibrary/0.5.1": {
-      "sha512": "WzEFvwrtqTMB0GFacjjbhwnPgyTzrsOLNTb7G9ms/Q+Ih6HpiUIL1d+BxqAaQN1pxfMegFoGXKRlILee7v1BMg==",
+    "PortableWebDavLibrary/0.6.1": {
+      "sha512": "959t6RbP1q/4PWQbjK9qVoX/sfGkBpMEltrWam7E3bWR925wrB1U3DMSI83jOjoTZdTfjYm6VO6kjxPaXbbkag==",
       "type": "package",
-      "path": "PortableWebDavLibrary/0.5.1",
+      "path": "PortableWebDavLibrary/0.6.1",
       "files": [
-        "PortableWebDavLibrary.0.5.1.nupkg.sha512",
+        "PortableWebDavLibrary.0.6.1.nupkg.sha512",
         "PortableWebDavLibrary.nuspec",
         "lib/DecaTec.WebDav.NetFx.dll",
         "lib/portable-Profile32/DecaTec.WebDav.Uwp.dll"
@@ -63,7 +63,7 @@
   "projectFileDependencyGroups": {
     "": [
       "Newtonsoft.Json >= 9.0.1",
-      "PortableWebDavLibrary >= 0.5.1"
+      "PortableWebDavLibrary >= 0.6.1"
     ],
     ".NETCore,Version=v4.5.1": []
   },


### PR DESCRIPTION
Update to the latest version of Portable WebDAV Library. There are some new features a few bugfixes compared to the version currently used.

Changelog of the library: https://github.com/DecaTec/Portable-WebDAV-Library/blob/master/changelog.md 