### PR TITLE
No application error on log in without user/pass

### DIFF
--- a/NextcloudApp/ViewModels/LoginPageViewModel.cs
+++ b/NextcloudApp/ViewModels/LoginPageViewModel.cs
@@ -12,6 +12,8 @@ using NextcloudClient.Exceptions;
 using Prism.Commands;
 using Prism.Windows.AppModel;
 using Prism.Windows.Navigation;
+using Windows.UI.Core;
+using Windows.System;
 
 namespace NextcloudApp.ViewModels
 {
@@ -75,6 +77,20 @@ namespace NextcloudApp.ViewModels
             _dialogService = dialogService;
 
             SaveSettingsCommand = new DelegateCommand(SaveSettings);
+            CoreWindow.GetForCurrentThread().KeyDown += LoginPageViewModel_KeyDown;
+        }
+
+        private void LoginPageViewModel_KeyDown(CoreWindow sender, KeyEventArgs args)
+        {
+            // Login in on 'Enter'.
+            switch (args.VirtualKey)
+            {
+                case VirtualKey.Enter:
+                    SaveSettingsCommand.Execute(null);
+                    break;
+                default:
+                    break;
+            }
         }
 
         public override void OnNavigatedTo(NavigatedToEventArgs e, Dictionary<string, object> dictionary)

--- a/NextcloudClient/NextcloudClient.cs
+++ b/NextcloudClient/NextcloudClient.cs
@@ -489,7 +489,7 @@ namespace NextcloudClient
         /// <returns></returns>
         public static async Task<bool> CheckUserLogin(string serverUrl, string userId, string password, bool ignoreServerCertificateErrors)
         {
-            if (serverUrl == null)
+            if (string.IsNullOrEmpty(serverUrl) || string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(password))
             {
                 return false;
             }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/windows-universal/issues/85

Furthermore, when hitting 'Enter' on the log in page now starts the log in process (that was a bit annoying when running the app on a (no touch) desktop system).