### PR TITLE
When moving a folder, the folder to move isn't shown as target

### DIFF
--- a/NextcloudApp/Services/DirectoryService.cs
+++ b/NextcloudApp/Services/DirectoryService.cs
@@ -133,6 +133,11 @@ namespace NextcloudApp.Services
 
         public async Task StartDirectoryListing()
         {
+            await StartDirectoryListing(null);
+        }
+
+        public async Task StartDirectoryListing(ResourceInfo resourceInfoToExclude)
+        {
             var client = await ClientService.GetClient();
             if (client == null)
             {
@@ -155,11 +160,16 @@ namespace NextcloudApp.Services
 
             FilesAndFolders.Clear();
             Folders.Clear();
+
             if (list != null)
             {
                 foreach (var item in list)
                 {
+                    if (resourceInfoToExclude != null && item == resourceInfoToExclude)
+                        continue;
+
                     FilesAndFolders.Add(new FileOrFolder(item));
+
                     if (item.IsDirectory())
                     {
                         Folders.Add(new FileOrFolder(item));

--- a/NextcloudApp/ViewModels/MoveFileOrFolderPageViewModel.cs
+++ b/NextcloudApp/ViewModels/MoveFileOrFolderPageViewModel.cs
@@ -298,7 +298,8 @@ namespace NextcloudApp.ViewModels
         {
             ShowProgressIndicator();
 
-            await Directory.StartDirectoryListing();
+            // The folder to move should not be set as target.
+            await Directory.StartDirectoryListing(ResourceInfo);
 
             HideProgressIndicator();
         }

--- a/NextcloudClient/Types/ResourceInfo.cs
+++ b/NextcloudClient/Types/ResourceInfo.cs
@@ -101,6 +101,50 @@ namespace NextcloudClient.Types
 	    {
 	        return JsonConvert.SerializeObject(this);
 	    }
-	}
+
+        #region Equals
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+                return false;
+
+            var other = obj as ResourceInfo;
+            return this.Equals(other);
+        }
+
+        public bool Equals(ResourceInfo other)
+        {
+            if (other == null)
+                return false;
+
+            return this.GetHashCode() == other.GetHashCode();
+        }
+
+        public static bool operator ==(ResourceInfo a, ResourceInfo b)
+        {
+            if (System.Object.ReferenceEquals(a, b))
+                return true;
+
+            if (((object)a == null) || ((object)b == null))
+                return false;
+
+            return a.GetHashCode() == b.GetHashCode();
+        }
+
+        public static bool operator !=(ResourceInfo a, ResourceInfo b)
+        {
+            return !(a == b);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = this.ContentType.GetHashCode() ^ this.Created.GetHashCode() ^ this.ETag.GetHashCode() ^ this.LastModified.GetHashCode() ^ this.Name.GetHashCode() 
+                ^ this.Path.GetHashCode() ^ this.Size.GetHashCode();
+            return hashCode;
+        }
+
+        #endregion Equals
+    }
 }
 


### PR DESCRIPTION
Resolves https://github.com/nextcloud/windows-universal/issues/75

Also, `ResourceInfo` implements `Equals`, `GetHashCode` and the corresponding operators.