### PR TITLE
New sort headers when sorted by file size

### DIFF
--- a/NextcloudApp/Services/DirectoryService.cs
+++ b/NextcloudApp/Services/DirectoryService.cs
@@ -152,8 +152,8 @@ namespace NextcloudApp.Services
         {
             var sizeMb = fileOrFolder.Size / 1024f / 1024f;
 
-            long[] sizesValuesMb = { 1, 10, 20, 30, 40, 50, 100, 1024, 5120, 10240, 102400 };
-            string[] sizesDisplay = { "<1MB", ">1MB", ">10MB", ">20MB", ">30MB", ">40MB", ">50MB", ">100MB", ">1GB", ">5GB", ">10GB", ">100GB" };
+            long[] sizesValuesMb = { 1, 5, 10, 25, 50, 100, 250, 500, 1024, 5120, 10240, 102400, 1048576 };
+            string[] sizesDisplay = { "<1MB", ">1MB", ">5MB", ">10MB", ">25MB", ">50MB", ">100MB", ">250MB", ">500MB", ">1GB", ">5GB", ">10GB", ">100GB", ">1TB" };
 
             var index = 0;
 

--- a/NextcloudApp/Services/DirectoryService.cs
+++ b/NextcloudApp/Services/DirectoryService.cs
@@ -26,29 +26,7 @@ namespace NextcloudApp.Services
             _groupedFilesAndFolders = new ObservableGroupingCollection<string, FileOrFolder>(FilesAndFolders);
             _groupedFolders = new ObservableGroupingCollection<string, FileOrFolder>(Folders);
 
-            switch (SettingsService.Instance.LocalSettings.GroupMode)
-            {
-                case GroupMode.GroupByNameAscending:
-                    GroupByNameAscending();
-                    break;
-                case GroupMode.GroupByNameDescending:
-                    GroupByNameDescending();
-                    break;
-                case GroupMode.GroupByDateAscending:
-                    GroupByDateAscending();
-                    break;
-                case GroupMode.GroupByDateDescending:
-                    GroupByDateDescending();
-                    break;
-                case GroupMode.GroupBySizeAscending:
-                    GroupBySizeAscending();
-                    break;
-                case GroupMode.GroupBySizeDescending:
-                    GroupBySizeDescending();
-                    break;
-                default:
-                    break;
-            }
+            SortList();
         }
 
         public static DirectoryService Instance => _instance ?? (_instance = new DirectoryService());
@@ -76,6 +54,33 @@ namespace NextcloudApp.Services
 
         public ObservableCollection<Grouping<string, FileOrFolder>> GroupedFilesAndFolders => _groupedFilesAndFolders.Items;
         public ObservableCollection<Grouping<string, FileOrFolder>> GroupedFolders => _groupedFolders.Items;
+
+        private void SortList()
+        {
+            switch (SettingsService.Instance.LocalSettings.GroupMode)
+            {
+                case GroupMode.GroupByNameAscending:
+                    GroupByNameAscending();
+                    break;
+                case GroupMode.GroupByNameDescending:
+                    GroupByNameDescending();
+                    break;
+                case GroupMode.GroupByDateAscending:
+                    GroupByDateAscending();
+                    break;
+                case GroupMode.GroupByDateDescending:
+                    GroupByDateDescending();
+                    break;
+                case GroupMode.GroupBySizeAscending:
+                    GroupBySizeAscending();
+                    break;
+                case GroupMode.GroupBySizeDescending:
+                    GroupBySizeDescending();
+                    break;
+                default:
+                    break;
+            }
+        }
 
         public void GroupByNameAscending()
         {
@@ -145,14 +150,22 @@ namespace NextcloudApp.Services
 
         private static string GetSizeHeader(ResourceInfo fileOrFolder)
         {
-            var size = fileOrFolder.Size;
-            string[] sizes = { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" };
-            var order = 0;
-            while (size >= 1024 && ++order < sizes.Length)
+            var sizeMb = fileOrFolder.Size / 1024f / 1024f;
+
+            long[] sizesValuesMb = { 1, 10, 20, 30, 40, 50, 100, 1024, 5120, 10240, 102400 };
+            string[] sizesDisplay = { "<1MB", ">1MB", ">10MB", ">20MB", ">30MB", ">40MB", ">50MB", ">100MB", ">1GB", ">5GB", ">10GB", ">100GB" };
+
+            var index = 0;
+
+            for (int i = 0; i < sizesValuesMb.Length; i++)
             {
-                size = size / 1024;
+                if (sizeMb > sizesValuesMb[i])
+                    index++;
+                else
+                    break;
             }
-            return sizes[order];
+
+            return sizesDisplay[index];
         }
 
         public async Task Refresh()
@@ -168,10 +181,9 @@ namespace NextcloudApp.Services
         public async Task StartDirectoryListing(ResourceInfo resourceInfoToExclude)
         {
             var client = await ClientService.GetClient();
+
             if (client == null)
-            {
                 return;
-            }
 
             _continueListing = true;
 
@@ -224,6 +236,8 @@ namespace NextcloudApp.Services
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+
+            SortList();
         }
 
         private async void DownloadPreviewImages()

--- a/NextcloudApp/Utils/SizeSorter.cs
+++ b/NextcloudApp/Utils/SizeSorter.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using NextcloudApp.Models;
-using NextcloudClient.Types;
 
 namespace NextcloudApp.Utils
 {


### PR DESCRIPTION
See https://github.com/nextcloud/windows-universal/issues/48

The available headers are: 
"<1MB", ">1MB", ">10MB", ">20MB", ">30MB", ">40MB", ">50MB", ">100MB", ">1GB", ">5GB", ">10GB", ">100GB"

Furthermore, the sorting was not correct directly after app start.

Are the predefined sizes ok, or should there be any other intervals?
