### PR TITLE
SettingsPage now has help icons showing additional info about the setting

### DIFF
--- a/NextcloudApp/Constants/ResourceConstants.cs
+++ b/NextcloudApp/Constants/ResourceConstants.cs
@@ -20,5 +20,9 @@
         public static string Cancel = "Cancel";
 
         public static string TryAgain = "TryAgain";
+
+        public static string HelpText_ExpertMode = "HelpTextExpertMode";
+
+        public static string HelpText_HelpTextIgnoreInvalidSelfSignedSslCertificates = "HelpTextIgnoreInvalidSelfSignedSslCertificates";
     }
 }

--- a/NextcloudApp/Strings/en/Resources.resw
+++ b/NextcloudApp/Strings/en/Resources.resw
@@ -441,7 +441,7 @@ Would you like to inform the application developers and submit the prepared erro
     <value>Connect</value>
   </data>
   <data name="IgnoreInvalidSelfSignedSslCertificates" xml:space="preserve">
-    <value>Ignore invalid self-signed SSL certificates. This allows invalid or incorrect SSL certificate authorities to be used. Be careful, you will not be protected from Man-in-the-middle (mitm) attacks anymore!</value>
+    <value>Ignore invalid self-signed SSL certificates</value>
   </data>
   <data name="ExpertMode.Header" xml:space="preserve">
     <value>Expert mode</value>
@@ -550,5 +550,11 @@ Please try again later.</value>
   </data>
   <data name="DirectoryListStatusBarText" xml:space="preserve">
     <value>Items: {0} (folders: {1} files: {2})</value>
+  </data>
+  <data name="HelpTextExpertMode" xml:space="preserve">
+    <value>When the expert mode is enabled, the app provides some additional features/information, which may not be interesting for all users.</value>
+  </data>
+  <data name="HelpTextIgnoreInvalidSelfSignedSslCertificates" xml:space="preserve">
+    <value>Ignore invalid self-signed SSL certificates. This allows invalid or incorrect SSL certificate authorities to be used. Be careful, you will not be protected from Man-in-the-middle (mitm) attacks anymore!</value>
   </data>
 </root>

--- a/NextcloudApp/ViewModels/SettingsPageViewModel.cs
+++ b/NextcloudApp/ViewModels/SettingsPageViewModel.cs
@@ -12,6 +12,8 @@ using Windows.UI.Xaml.Controls;
 using NextcloudApp.Constants;
 using Windows.UI.Xaml;
 using Prism.Unity.Windows;
+using Windows.UI.Popups;
+using System.Threading.Tasks;
 
 namespace NextcloudApp.ViewModels
 {
@@ -28,6 +30,8 @@ namespace NextcloudApp.ViewModels
         private bool _expertMode;
 
         public ICommand ResetCommand { get; private set; }
+        public ICommand ShowHelpExpertModeCommand { get; private set; }
+        public ICommand ShowHelpIgnoreInvalidSslCertificatesCommand { get; private set; }
 
         public SettingsPageViewModel(INavigationService navigationService, IResourceLoader resourceLoader, DialogService dialogService)
         {
@@ -74,6 +78,8 @@ namespace NextcloudApp.ViewModels
             ExpertMode = Settings.ExpertMode;
 
             ResetCommand = new DelegateCommand(Reset);
+            ShowHelpExpertModeCommand = new DelegateCommand(ShowHelpExpertMode);
+            ShowHelpIgnoreInvalidSslCertificatesCommand = new DelegateCommand(ShowHelpInvalidSslCertificates);
 
             GetServerVersion();
         }
@@ -221,6 +227,24 @@ namespace NextcloudApp.ViewModels
         {
             SettingsService.Instance.Reset();
             _navigationService.Navigate(PageToken.Login.ToString(), null);
+        }
+
+        private async void ShowHelpExpertMode()
+        {
+            var text = _resourceLoader.GetString(ResourceConstants.HelpText_ExpertMode);
+            await ShowHelp(text);
+        }
+
+        private async void ShowHelpInvalidSslCertificates()
+        {
+            var text = _resourceLoader.GetString(ResourceConstants.HelpText_HelpTextIgnoreInvalidSelfSignedSslCertificates);
+            await ShowHelp(text);
+        }
+
+        private async Task ShowHelp(string message)
+        {
+            var messageDialog = new MessageDialog(message, string.Empty);
+            await _dialogService.ShowAsync(messageDialog);
         }
     }
 }

--- a/NextcloudApp/Views/SettingsPage.xaml
+++ b/NextcloudApp/Views/SettingsPage.xaml
@@ -22,6 +22,30 @@
                 </Setter.Value>
             </Setter>
         </Style>
+
+        <DataTemplate x:Key="HelpButtonDataTemplate">
+            <Viewbox Height="32" Width="32">
+                <Grid>
+                    <Grid Name="backgroundGrid" Width="128" Height="128" Visibility="Collapsed" />
+                    <Path Data="M16.015988,22.000006C16.587003,22.000006 17.059996,22.190009 17.436003,22.570014 17.812011,22.941992 17.999999,23.414008 17.999999,23.988015 17.999999,24.570015 17.815001,25.051003 17.44699,25.430001 17.070982,25.810006 16.593992,26.000008 16.015988,26.000008 15.437985,26.000008 14.956997,25.806008 14.574001,25.418007 14.191005,25.014016 13.999995,24.538002 13.999995,23.988015 13.999995,23.422003 14.191005,22.950018 14.574001,22.570014 14.956997,22.190009 15.437985,22.000006 16.015988,22.000006z M16.432004,5.8760081C17.279997,5.8760079 18.067992,5.9700021 18.798004,6.1560069 19.527009,6.3429881 20.161989,6.6369945 20.704988,7.0379959 21.247012,7.4389968 21.670993,7.9519975 21.975986,8.5759909 22.28101,9.2009907 22.433994,9.9500146 22.433994,10.825015 22.433994,11.381015 22.369999,11.885013 22.243015,12.336002 22.114994,12.786991 21.928013,13.213016 21.68201,13.613987 21.436007,14.015995 21.131015,14.399998 20.765993,14.769993 20.40201,15.139012 19.981996,15.519993 19.509004,15.911015 19.188996,16.175999 18.908997,16.422001 18.667999,16.648991 18.425994,16.876989 18.225006,17.103002 18.066009,17.325994 17.906005,17.549993 17.78601,17.786993 17.704009,18.036993 17.622008,18.288 17.580992,18.573003 17.580992,18.892004 17.580992,19.109991 17.609984,19.33399 17.669982,19.562018 17.729003,19.790015 17.807982,19.980994 17.908996,20.135993L14.312984,20.135993C14.22198,19.898993 14.150996,19.631995 14.100978,19.336004 14.05099,19.040014 14.025996,18.760015 14.025996,18.495 14.025996,18.075994 14.066981,17.692998 14.148982,17.34699 14.230983,17.000005 14.353999,16.674992 14.518001,16.368992 14.682003,16.064 14.886989,15.772007 15.133999,15.493992 15.380001,15.216008 15.666989,14.940007 15.994992,14.666996 16.341001,14.375004 16.64401,14.104007 16.90399,13.854008 17.164,13.603001 17.384001,13.353 17.566985,13.101993 17.748992,12.851017 17.885985,12.591007 17.976989,12.321994 18.067992,12.053988 18.113983,11.755008 18.113983,11.427005 18.113983,11.144992 18.063994,10.881991 17.963988,10.640994 17.863006,10.398989 17.718993,10.191988 17.532988,10.019015 17.346007,9.8460104 17.11801,9.7089865 16.848997,9.6080039 16.579984,9.5079978 16.28201,9.45801 15.954007,9.45801 15.243008,9.45801 14.505,9.6059897 13.738978,9.9020104 12.972986,10.199008 12.248986,10.647006 11.564995,11.248996L11.564995,7.1340042C12.266991,6.7149975 13.032007,6.3999949 13.861994,6.1900035 14.691005,5.9809884 15.548001,5.8760079 16.432004,5.8760081z M16,2C8.2799997,2.0000002 2,8.2800002 2,16 2,23.72 8.2799997,30 16,30 23.719999,30 30,23.72 30,16 30,8.2800002 23.719999,2.0000002 16,2z M16,0C24.822,0 32,7.1780001 32,16 32,24.822001 24.822,32 16,32 7.1779995,32 0,24.822001 0,16 0,7.1780001 7.1779995,0 16,0z" Stretch="Uniform" Fill="#FFFFFFFF" Width="68" Height="68" Margin="0,0,0,0" RenderTransformOrigin="0.5,0.5"></Path>
+                </Grid>
+            </Viewbox>
+        </DataTemplate>
+
+        <Style x:Key="HelpButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Grid Background="{TemplateBinding Background}">
+                            <ContentPresenter />
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <Setter Property="ContentTemplate" Value="{StaticResource HelpButtonDataTemplate}">
+            </Setter>
+        </Style>
     </prismMvvm:SessionStateAwarePage.Resources>
 
     <Grid Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}">
@@ -33,8 +57,20 @@
         <TextBlock Text="Settings" x:Uid="Settings2" Margin="48,0,0,0" VerticalAlignment="Center"/>
 
         <ScrollViewer Grid.Row="1" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-            <StackPanel Orientation="Vertical" Margin="12">
-                <!--
+            <StackPanel Orientation="Vertical">
+                <Grid Margin="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"></ColumnDefinition>
+                        <ColumnDefinition Width="25"></ColumnDefinition>
+                        <ColumnDefinition Width="Auto"></ColumnDefinition>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"></RowDefinition>
+                        <RowDefinition Height="Auto"></RowDefinition>
+                        <RowDefinition Height="Auto"></RowDefinition>
+                        <RowDefinition Height="Auto"></RowDefinition>
+                    </Grid.RowDefinitions>
+                    <!--
                 <ToggleSwitch 
                     x:Uid="ShowGrouping"
                     Header="Show file and folder list grouping header"
@@ -42,44 +78,55 @@
                     IsOn="{Binding Settings.ShowFileAndFolderGroupingHeader, Mode=TwoWay}"/>
                 -->
 
-                <ComboBox 
+                    <ComboBox 
+                    Grid.Column="0"
+                    Grid.Row="0"
                     Header="Download preview images"
                     x:Uid="DownloadPreviewImages"
                     ItemsSource="{Binding PreviewImageDownloadModes}"
                     SelectedIndex="{Binding PreviewImageDownloadModesSelectedIndex, Mode=TwoWay}"
                     Margin="0,12"/>
 
-                <ToggleSwitch 
+                    <ToggleSwitch 
+                    Grid.Column="0"
+                    Grid.Row="1"
                     x:Uid="UseWindowsHello"
                     Header="Windows Hello authentication"
                     Margin="0,12"
                     IsOn="{Binding UseWindowsHello, Mode=TwoWay}">
-                    <interactivity:Interaction.Behaviors>
-                        <Core:EventTriggerBehavior EventName="Toggled">
-                            <Core:CallMethodAction TargetObject="{Binding}" MethodName="UseWindowsHelloToggled"></Core:CallMethodAction>
-                        </Core:EventTriggerBehavior>
-                    </interactivity:Interaction.Behaviors>
-                </ToggleSwitch>
+                        <interactivity:Interaction.Behaviors>
+                            <Core:EventTriggerBehavior EventName="Toggled">
+                                <Core:CallMethodAction TargetObject="{Binding}" MethodName="UseWindowsHelloToggled"></Core:CallMethodAction>
+                            </Core:EventTriggerBehavior>
+                        </interactivity:Interaction.Behaviors>
+                    </ToggleSwitch>
 
-                <ToggleSwitch 
+                    <ToggleSwitch 
+                        Grid.Column="0"
+                        Grid.Row="2"
                     x:Uid="IgnoreInvalidSelfSignedSslCertificates"
-                    Header="Ignore invalid self-signed SSL certificates. This allows invalid or incorrect SSL certificate authorities to be used. Be careful, you will not be protected from Man-in-the-middle (mitm) attacks anymore!"
+                    Header="Ignore invalid self-signed SSL certificates"
                     Margin="0,12"
                     IsOn="{Binding IgnoreServerCertificateErrors, Mode=TwoWay}">
-                    <interactivity:Interaction.Behaviors>
-                        <Core:EventTriggerBehavior EventName="Toggled">
-                            <Core:CallMethodAction TargetObject="{Binding}" MethodName="IgnoreServerCertificateErrorsToggled"></Core:CallMethodAction>
-                        </Core:EventTriggerBehavior>
-                    </interactivity:Interaction.Behaviors>
-                </ToggleSwitch>
+                        <interactivity:Interaction.Behaviors>
+                            <Core:EventTriggerBehavior EventName="Toggled">
+                                <Core:CallMethodAction TargetObject="{Binding}" MethodName="IgnoreServerCertificateErrorsToggled"></Core:CallMethodAction>
+                            </Core:EventTriggerBehavior>
+                        </interactivity:Interaction.Behaviors>
+                    </ToggleSwitch>
+                    <Button Grid.Column="2" Grid.Row="2" Command="{Binding ShowHelpIgnoreInvalidSslCertificatesCommand, Mode=OneTime}" Style="{StaticResource HelpButtonStyle}"></Button>
 
-                <ToggleSwitch 
+
+                    <ToggleSwitch 
+                        Grid.Column="0"
+                        Grid.Row="3"
                     x:Uid="ExpertMode"
-                    Header="Developer mode"
+                    Header="Expert mode"
                     Margin="0,12"
-                    IsOn="{Binding ExpertMode, Mode=TwoWay}">                    
-                </ToggleSwitch>
-
+                    IsOn="{Binding ExpertMode, Mode=TwoWay}">
+                    </ToggleSwitch>
+                    <Button Grid.Column="2" Grid.Row="3" Command="{Binding ShowHelpExpertModeCommand, Mode=OneTime}" Style="{StaticResource HelpButtonStyle}"></Button>                   
+                </Grid>
                 <Border 
                     Margin="0,12" 
                     Background="{ThemeResource SystemControlForegroundBaseMediumBrush}" 


### PR DESCRIPTION
This is due to the "Ignore invalid SSL..." option: The text was too long.
Now the option header can be short and we provide additional help with a button/popup.