### PR TITLE
Remove icon (marker) for non-favorite items

### DIFF
--- a/NextcloudApp/Converter/FavoriteToIconConverter.cs
+++ b/NextcloudApp/Converter/FavoriteToIconConverter.cs
@@ -9,7 +9,7 @@ namespace NextcloudApp.Converter
         public object Convert(object value, Type targetType, object parameter, string language)
         {
             var item = (ResourceInfo)value;
-            return item.IsFavorite ? "\uE735" : "\uE734";
+            return item.IsFavorite ? "\uE735" : "";
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)


### PR DESCRIPTION
To avoid confusion for the user and to keep the UI simple, we should not show a icon (marker) for non favorite items.

If the item is clickable (to mark it as favorite) it should be shown again. But by now, we should just hide it.