### PR TITLE
#108 name unexpected exceptions in sync service as such

### DIFF
--- a/NextcloudApp/Services/SyncService.cs
+++ b/NextcloudApp/Services/SyncService.cs
@@ -97,10 +97,7 @@ namespace NextcloudApp.Services
                 }
                 catch (Exception e)
                 {
-                    if (sid != null)
-                    {
-                        sid.Error = e.Message;
-                    }
+                    sid.Error = string.Format(_resourceLoader.GetString("UnexpectedException"), e.Message);
                     errorCount++;
                 }
 
@@ -279,7 +276,7 @@ namespace NextcloudApp.Services
             }
             catch (Exception e)
             {
-                sid.Error = e.Message;
+                sid.Error = string.Format(_resourceLoader.GetString("UnexpectedException"), e.Message);
             }
             _sidList.Add(sid);
             SyncDbUtils.SaveSyncInfoDetail(sid);
@@ -573,7 +570,7 @@ namespace NextcloudApp.Services
             catch (Exception e)
             {
                 // TODO: do not write only the raw exception message in the sid.Error.
-                sid.Error = e.Message;
+                sid.Error = string.Format(_resourceLoader.GetString("UnexpectedException"), e.Message);
             }
             Debug.WriteLine("Synced file " + sid);
             _sidList.Add(sid);

--- a/NextcloudApp/Strings/en/Resources.resw
+++ b/NextcloudApp/Strings/en/Resources.resw
@@ -639,4 +639,8 @@ Please try again later.</value>
   <data name="Overwrite" xml:space="preserve">
     <value>Overwrite</value>
   </data>
+  <data name="UnexpectedException" xml:space="preserve">
+    <value>Unexpected Exception: {0}</value>
+    <comment>{0} exception details</comment>
+  </data>
 </root>


### PR DESCRIPTION
@DecaTec The general catch blocks are needed, cause the sync service should not throw any exceptions. When used as background task, there is no way to handle those exceptions. I added a localized prefix to the unexpected exceptions.
All exceptions we can name more accurate should of course be named in the code within.