### PR TITLE
Fixed app crash when trying to log in without server URL specified.

### DIFF
--- a/NextcloudApp/Constants/ResourceConstants.cs
+++ b/NextcloudApp/Constants/ResourceConstants.cs
@@ -39,6 +39,8 @@
 
         public static string ThemeLight = "ThemeLight";
 
+        public static string NoServerGiven = "NoServerGiven";
+
         #region SyncService
 
         public static string SyncService_Error_CannotCreateClient = "SyncService_Error_CannotCreateClient";

--- a/NextcloudApp/Strings/en/Resources.resw
+++ b/NextcloudApp/Strings/en/Resources.resw
@@ -643,4 +643,7 @@ Please try again later.</value>
     <value>Unexpected Exception: {0}</value>
     <comment>{0} exception details</comment>
   </data>
+  <data name="NoServerGiven" xml:space="preserve">
+    <value>No server URL specified. Please enter the URL of your Nextcloud instance.</value>
+  </data>
 </root>

--- a/NextcloudApp/ViewModels/LoginPageViewModel.cs
+++ b/NextcloudApp/ViewModels/LoginPageViewModel.cs
@@ -14,6 +14,7 @@ using Prism.Windows.AppModel;
 using Prism.Windows.Navigation;
 using Windows.UI.Core;
 using Windows.System;
+using NextcloudApp.Constants;
 
 namespace NextcloudApp.ViewModels
 {
@@ -203,6 +204,12 @@ namespace NextcloudApp.ViewModels
 
         private async Task<bool> CheckAndFixServerAddress()
         {
+            if (string.IsNullOrEmpty(ServerAddress))
+            {
+                await ShowEmptyServerAddressMessage();
+                return false;
+            }
+
             if (!ServerAddress.StartsWith("http"))
             {
                 ServerAddress = string.Format("https://{0}", ServerAddress);
@@ -293,6 +300,22 @@ namespace NextcloudApp.ViewModels
                 Content = new TextBlock
                 {
                     Text = string.Format(_resourceLoader.GetString("ServerWithGivenAddressIsNotReachable"), _serverAddressGivenByUser),
+                    TextWrapping = TextWrapping.WrapWholeWords,
+                    Margin = new Thickness(0, 20, 0, 0)
+                },
+                PrimaryButtonText = _resourceLoader.GetString("OK")
+            };
+            await _dialogService.ShowAsync(dialog);
+        }
+
+        private async Task ShowEmptyServerAddressMessage()
+        {
+            var dialog = new ContentDialog
+            {
+                Title = _resourceLoader.GetString("AnErrorHasOccurred"),
+                Content = new TextBlock
+                {
+                    Text = _resourceLoader.GetString(ResourceConstants.NoServerGiven),
                     TextWrapping = TextWrapping.WrapWholeWords,
                     Margin = new Thickness(0, 20, 0, 0)
                 },


### PR DESCRIPTION
When on the login screen an just clicking"connect" without specifying a server URL, the app crashed.