### PR TITLE
clear the file & folder list instantly, to avoid user confusion

### DIFF
--- a/NextcloudApp/Services/DirectoryService.cs
+++ b/NextcloudApp/Services/DirectoryService.cs
@@ -216,8 +216,12 @@ namespace NextcloudApp.Services
             await StartDirectoryListing(null);
         }
 
-        public async Task StartDirectoryListing(ResourceInfo resourceInfoToExclude, String viewName = null)
+        public async Task StartDirectoryListing(ResourceInfo resourceInfoToExclude, string viewName = null)
         {
+            // clear instantly, so the user will not see invalid listings
+            FilesAndFolders.Clear();
+            Folders.Clear();
+
             var client = await ClientService.GetClient();
 
             if (client == null || IsSelecting)
@@ -264,9 +268,6 @@ namespace NextcloudApp.Services
             {
                 ResponseErrorHandlerService.HandleException(e);
             }
-
-            FilesAndFolders.Clear();
-            Folders.Clear();
 
             if (list != null)
             {

--- a/NextcloudApp/ViewModels/FavoritesPageViewModel.cs
+++ b/NextcloudApp/ViewModels/FavoritesPageViewModel.cs
@@ -9,21 +9,14 @@ namespace NextcloudApp.ViewModels
 {
     public class FavoritesPageViewModel : DirectoryListPageViewModel
     {
-        private TileService _tileService;
         private ResourceInfo _selectedFileOrFolder;
         private readonly INavigationService _navigationService;
-        private readonly IResourceLoader _resourceLoader;
-        private readonly DialogService _dialogService;
         private bool _isNavigatingBack;
 
         public FavoritesPageViewModel(INavigationService navigationService, IResourceLoader resourceLoader, DialogService dialogService)
             : base(navigationService, resourceLoader, dialogService)
         {
             _navigationService = navigationService;
-            _resourceLoader = resourceLoader;
-            _dialogService = dialogService;
-            _tileService = TileService.Instance;
-
         }
 
         public override void OnNavigatedTo(NavigatedToEventArgs e, Dictionary<string, object> viewModelState)
@@ -32,11 +25,12 @@ namespace NextcloudApp.ViewModels
             StartDirectoryListing();
             _isNavigatingBack = false;
 
-            if (e.Parameter != null)
+            if (e.Parameter == null)
             {
-                var parameter = FileInfoPageParameters.Deserialize(e.Parameter);
-                SelectedFileOrFolder = parameter?.ResourceInfo;
+                return;
             }
+            var parameter = FileInfoPageParameters.Deserialize(e.Parameter);
+            SelectedFileOrFolder = parameter?.ResourceInfo;
         }
 
         public override void OnNavigatingFrom(NavigatingFromEventArgs e, Dictionary<string, object> viewModelState, bool suspending)
@@ -53,7 +47,7 @@ namespace NextcloudApp.ViewModels
 
         public override ResourceInfo SelectedFileOrFolder
         {
-            get { return _selectedFileOrFolder; }
+            get => _selectedFileOrFolder;
             set
             {
                 if (_isNavigatingBack)
@@ -145,7 +139,8 @@ namespace NextcloudApp.ViewModels
 
             HideProgressIndicator();
             SelectedFileOrFolder = null;
-            RaisePropertyChanged(nameof(DirectoryListPageViewModel.StatusBarText));
+            // ReSharper disable once ExplicitCallerInfoArgument
+            RaisePropertyChanged(nameof(StatusBarText));
         }
     }
 }


### PR DESCRIPTION
do not show wrong data / wrong data from wrong (previous) context